### PR TITLE
Drop IE11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ We use React as our UI framework, but that can be replaced if need be. With our 
 
 ### Browser support
 
-This starter is tested in Chrome, Firefox, Safari and IE11, but we can safely assume that it works in all browsers covered by our `browserslist` specification. We include both `core-js` and `regenerator-runtime` on our frontend bundle. Babel then converts that on individual polyfills, so we only include polyfills we actually need.
+This starter is tested in Chrome, Firefox and Safari, but we can safely assume that it works in all browsers covered by our `browserslist` specification.
 
-Check used polyfills on `frontend/shared/polyfills.js`.
+No polyfill are setup on this starter as IE11 is not supported. [Check babel's docs](https://babeljs.io/docs/en/babel-preset-env) for info on supporting older browsers. We are also using `fetch` so don't forget to polyfill that too.
 
 ## Backend
 The only backend logic present is the user authentication. We created a custom session controller to handle logins and logouts using the Sorcery gem. By default the Sorcery gem only:

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,5 +1,3 @@
-// Polyfills should be imported before EVERYTHING
-import "root/shared/polyfills";
 import React from "react";
 import ReactDOM from "react-dom";
 

--- a/frontend/shared/polyfills.js
+++ b/frontend/shared/polyfills.js
@@ -1,4 +1,0 @@
-import "core-js/stable";
-import "regenerator-runtime/runtime";
-
-if (!("fetch" in window)) import("unfetch/polyfill/index");

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@rails/webpacker": "^6.0.0-beta.6",
     "@testing-library/react": "^11.2.5",
     "babel-loader": "^8.2.2",
-    "core-js": "^3.9.1",
     "css-loader": "^5.1.2",
     "css-minimizer-webpack-plugin": "^1.2.0",
     "cssnano": "^4.1.10",
@@ -35,14 +34,11 @@
     "react-imported-component": "^6.4.1",
     "react-router-dom": "^5.2.0",
     "redaxios": "^0.4.1",
-    "regenerator-runtime": "^0.13.7",
-    "unfetch": "^4.2.0",
     "webpack": "^5.11.0",
     "webpack-cli": "^4.2.0"
   },
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
-    "@webpack-cli/serve": "^1.3.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.3",
     "dotenv-webpack": "^7.0.1",
@@ -57,7 +53,6 @@
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "react-refresh": "^0.9.0",
-    "react-test-renderer": "^17.0.1",
     "stylelint": "^13.12.0",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-order": "^4.1.0",
@@ -72,7 +67,8 @@
     }
   },
   "browserslist": [
-    "> 0.25%",
-    "not dead"
+    "> 2%",
+    "not dead",
+    "not IE 11"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3074,7 +3074,7 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-js@^3.8.0, core-js@^3.9.1:
+core-js@^3.8.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.1.tgz#cec8de593db8eb2a85ffb0dbdeb312cb6e5460ae"
   integrity sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==
@@ -8179,15 +8179,15 @@ react-imported-component@^6.4.1:
     scan-directory "^2.0.0"
     tslib "^2.0.0"
 
-"react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
-  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
-
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 react-refresh@^0.9.0:
   version "0.9.0"
@@ -8222,24 +8222,6 @@ react-router@5.2.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
-
-react-shallow-renderer@^16.13.1:
-  version "16.14.1"
-  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz#bf0d02df8a519a558fd9b8215442efa5c840e124"
-  integrity sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==
-  dependencies:
-    object-assign "^4.1.1"
-    react-is "^16.12.0 || ^17.0.0"
-
-react-test-renderer@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3187e636c3063e6ae498aedf21ecf972721574c7"
-  integrity sha512-/dRae3mj6aObwkjCcxZPlxDFh73XZLgvwhhyON2haZGUEhiaY5EjfAdw+d/rQmlcFwdTpMXCSGVk374QbCTlrA==
-  dependencies:
-    object-assign "^4.1.1"
-    react-is "^17.0.1"
-    react-shallow-renderer "^16.13.1"
-    scheduler "^0.20.1"
 
 react@^17.0.1:
   version "17.0.1"
@@ -9707,11 +9689,6 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
-
-unfetch@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
-  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
To improve performance and reduce the number of polyfills and code transformations made by `babel` 