### PR TITLE
Regenerate CSRF token on each request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,25 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  around_action :attach_csrf_token_to_header
 
   private
 
+  # SORCERY OVERRIDE
+  #
+  # Respond with a not found response when not authenticated
   def not_authenticated
     head :not_found
+  end
+
+  # SORCERY OVERRIDE
+  #
+  # Set the response after the yield of a controller action
+  # so that each request always has the csrf token on the
+  # headers of the response
+  def attach_csrf_token_to_header
+    yield
+
+    token = session[:_csrf_token] || form_authenticity_token
+    response.headers["X-CSRF-Token"] = token
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <script>
+      const originalFetch = window.fetch;
+      let csrfToken = document.querySelector("meta[name=csrf-token]").content;
+
+      window.fetch = async (resource, options = {}) => {
+        const defaultHeaders = options.headers || {};
+        const fetchResult = await originalFetch(resource, {
+          ...options,
+          headers: { ...defaultHeaders, "X-CSRF-Token": csrfToken },
+        });
+
+        csrfToken = fetchResult.headers.get("X-CSRF-Token");
+
+        return fetchResult;
+      };
+    </script>
 
     <%= javascript_pack_tag 'application' %>
     <%= stylesheet_pack_tag 'application' %>

--- a/frontend/api/setupCsrfToken.js
+++ b/frontend/api/setupCsrfToken.js
@@ -1,7 +1,0 @@
-import redaxios from "redaxios";
-
-export default function setupCsrfToken() {
-  const csrfToken = document.querySelector("meta[name=csrf-token]").content;
-
-  redaxios.defaults.headers = { "X-CSRF-Token": csrfToken };
-}

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -2,12 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import App from "root/components/App";
-import setupCsrfToken from "root/api/setupCsrfToken";
 
 import "./styles/reset.css";
 
 window.addEventListener("DOMContentLoaded", () => {
-  setupCsrfToken();
-
   ReactDOM.render(<App />, document.getElementById("root"));
 });


### PR DESCRIPTION
Based on Tânia's work, I created an abstract solution to rotate the CSRF token on every request. 

Check #611 

The previous issue was: when a user logs out, he needed a new CSRF token, and our frontend app didn't handle that (you would need to refresh).