### PR TITLE
Remove `postcss-color-function`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "css-minimizer-webpack-plugin": "^3.4.1",
     "cssnano": "^5.1.11",
     "mini-css-extract-plugin": "^2.6.0",
-    "postcss-color-function": "^4.1.0",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-import": "^14.1.0",
     "postcss-preset-env": "^6.7.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -23,7 +23,6 @@ module.exports = {
       },
       stage: 3
     }),
-    require("postcss-color-function"),
     require("postcss-flexbugs-fixes"),
     process.env.NODE_ENV === "production"
       ? require("cssnano")({


### PR DESCRIPTION
Why:
* We don't seem to be using it and it is causing a vulnerability warning
  due to the package not being update to support `postcss@8`

How:
* Removing the `postcss-color-function` package from `package.json` and
  from the PostCSS config file
